### PR TITLE
bump deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,10 +11,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-eff": "^0.1.2",
-    "purescript-datetime": "^0.9.1",
-    "purescript-dom": "^0.2.17",
-    "purescript-globals": "^0.2.2",
-    "purescript-integers": "^0.2.1"
+    "purescript-eff": "^2.0.0",
+    "purescript-datetime": "^2.0.0",
+    "purescript-dom": "^3.3.1",
+    "purescript-globals": "^2.0.0",
+    "purescript-integers": "^2.1.0"
   }
 }


### PR DESCRIPTION
My testing was `pulp build` with PSC v0.10.3. Compilation failed when using current deps, but pass when using these deps, which are all latest versions.